### PR TITLE
Update env_logger crate to decrease image size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-env_logger="0.6"
+env_logger="0.9"


### PR DESCRIPTION
The script with version 0.6 of env_logger creates a docker image size of 5.04MB. With version 0.9 the overall image size is reduced to 4.63MB.